### PR TITLE
Support abstract vectors/arrays even if different types or complex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,13 @@ name = "AngleBetweenVectors"
 author = "Jeffrey Sarnoff <jeffrey.sarnoff@gmail.com>"
 uuid = "ec570357-d46e-52ed-9726-18773498274d"
 repo = "https://github.com/JeffreySarnoff/AngleBetweenVectors.jl.git"
-version = "v0.3.0"
+version = "v0.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/AngleBetweenVectors.jl
+++ b/src/AngleBetweenVectors.jl
@@ -4,6 +4,7 @@ import Base: angle
 
 import LinearAlgebra: norm
 
+Floats = Union{AbstractFloat, Complex{T} where T<:AbstractFloat}
 
 @inline unitize(p) = p ./ norm(p)
 
@@ -20,17 +21,17 @@ Prefer this to `acos` alternatives
 Suggested when any |coordinate| of either point may be outside 2^±20 or [1/1_000_000, 1_000_000].
 Strongly recommended when any |coordinate| is outside 2^±24 or [1/16_000_000, 16_000_000].
 
-If one of the points is at the origin, the result is zero.
+If either of the points is at the origin, the result is `NaN` because angle is undefined in that case.
 
 You *must* define a tuple constructor `Tuple(x::YourPointType) = ...` if one does not already exist.
 """
-angle(tuple1::NTuple{N,T}, tuple2::NTuple{N,T}) where {N, T<:AbstractFloat} = angle(T, tuple1, tuple2)
+angle(tuple1::NTuple{N,T}, tuple2::NTuple{N,T}) where {N, T<:Floats} = angle(real(T), tuple1, tuple2)
 
 # because of the broadcasts .- and .+ below, it is essential to check size compatibility
 # for arrays, whereas for tuples the consistency ensured by the "N" in the type
-function angle(a1::AbstractArray{T}, a2::AbstractArray{T}) where {D, T<:AbstractFloat}
+function angle(a1::AbstractArray{T}, a2::AbstractArray{T}) where {T<:Floats}
 	size(a1) == size(a2) || throw(DimensionMismatch())
-    return angle(T, a1, a2)
+    return angle(real(T), a1, a2)
 end
 
 function angle(::Type{T}, point1, point2) where {T<:AbstractFloat}
@@ -46,7 +47,7 @@ function angle(::Type{T}, point1, point2) where {T<:AbstractFloat}
 end
 
 # this method allows the arrays to have different types, even non-float types
-function angle(a1::AbstractArray{T1}, a2::AbstractArray{T2}) where {T1 <: Real, T2 <: Real}
+function angle(a1::AbstractArray{T1}, a2::AbstractArray{T2}) where {T1 <: Number, T2 <: Number}
     T = float(promote_type(T1, T2)) # the "T" for T(pi) must be a float type
     return angle(convert(AbstractArray{T}, a1), convert(AbstractArray{T}, a2))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,3 +18,8 @@ point2 = (0.0,  1.0, 0.0, -1.0)
 # note: 2pi/3 !== Float64(2*BigFloat(pi)/3)
 @test angle(point1, point2) == Float64(2*BigFloat(pi)/3)
 @test angle(point1, point2) == angle(point2, point1)
+
+@test (@inferred angle(1:3, 1:3)) == 0.0f0
+@test (@inferred angle(0:1, -1:0)) == pi/2
+@test (@inferred angle(0:1, -1.0:0.0)) == pi/2
+@test (@inferred angle(Real[0.0 1], Int16[-1 0])) == pi/2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,9 @@ point2 = (0.0,  1.0, 0.0, -1.0)
 @test angle(point1, point2) == Float64(2*BigFloat(pi)/3)
 @test angle(point1, point2) == angle(point2, point1)
 
-@test (@inferred angle(1:3, 1:3)) == 0.0f0
-@test (@inferred angle(0:1, -1:0)) == pi/2
-@test (@inferred angle(0:1, -1.0:0.0)) == pi/2
-@test (@inferred angle(Real[0.0 1], Int16[-1 0])) == pi/2
+@test (@inferred angle(0:1, -1:0)) == pi/2 # abstract vector
+@test (@inferred angle(0:1, -1.0:0.0)) == pi/2 # different eltype
+@test (@inferred angle(Real[0.0 1], Int16[-1 0])) == pi/2 # array
+@test (@inferred angle(0:1, (-1.0:0.0)*1im)) == pi/2 # complex
+
+@test isnan(@inferred angle(zeros(2), 1:2)) # zero point returns NaN


### PR DESCRIPTION
This PR adds support for the angle between two `AbstractArrays` (of compatible dimensions) even if they have different element types and even if the elements are non-float reals (i.e., integers) or if they are complex.

Added tests exercise the additional flexibility.

If this type of generalization is welcome then I can also add comment about it to the docstring and README if you want.

Also fixes the previously inaccurate comment about a zero point, perhaps addressing #2.